### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/maelcs/juice-shop-ada-1497/security/code-scanning/73](https://github.com/maelcs/juice-shop-ada-1497/security/code-scanning/73)

The best way to fix this issue is to avoid using the `$where` operator entirely for matching by user input. Instead, use a regular field query, e.g., `{ orderId: id }`, which safely matches documents based on the value of `orderId` and does not evaluate any user-provided code. This change preserves existing application functionality (searching for orders by ID), while eliminating the vector for code injection. Specifically, replace line 18 from:

```ts
db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
```

to:

```ts
db.ordersCollection.find({ orderId: id }).then((order: any) => {
```

No additional methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
